### PR TITLE
Integrate Keystatic CMS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+package-lock.json
+npm-debug.log*

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# personalsite
+# Personal Site
+
+This repository contains the static files for my personal website. Content can be managed using [Keystatic](https://keystatic.dev).
+
+## Local development
+
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Start the Keystatic CMS:
+   ```bash
+   npm run dev
+   ```
+   The CMS will be available at `http://localhost:3000`.
+
+Content lives in the `content/` directory and is defined in `keystatic.config.ts`.

--- a/content/posts/first-post.md
+++ b/content/posts/first-post.md
@@ -1,0 +1,5 @@
+---
+title: "First Post"
+---
+
+This is my first post managed by Keystatic.

--- a/keystatic.config.ts
+++ b/keystatic.config.ts
@@ -1,0 +1,19 @@
+import { config, fields } from '@keystatic/core';
+
+export default config({
+  storage: {
+    kind: 'github',
+    repo: 'yourusername/rayhan.id',
+    branch: 'main',
+  },
+  collections: {
+    posts: {
+      label: 'Posts',
+      path: 'content/posts/*',
+      schema: {
+        title: fields.text({ label: 'Title' }),
+        content: fields.markdown({ label: 'Content' }),
+      },
+    },
+  },
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "rayhan.id",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "directories": {
+    "lib": "lib"
+  },
+  "scripts": {
+    "dev": "keystatic dev"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "@keystatic/core": "^0.5.47",
+    "keystatic": "^0.0.36"
+  }
+}


### PR DESCRIPTION
## Summary
- add basic keystatic config and sample post
- setup npm project with keystatic dependencies
- document CMS usage in README
- ignore node_modules

## Testing
- `npm audit --audit-level=critical`


------
https://chatgpt.com/codex/tasks/task_e_683fb0f0474c8324923285db4d600e7b